### PR TITLE
Update from sql= to query= throughout the compliance

### DIFF
--- a/cis_kube_v120/cis_kube_v120_v100.sp
+++ b/cis_kube_v120/cis_kube_v120_v100.sp
@@ -118,7 +118,7 @@ benchmark "cis_kube_v120_v100_5_7_4" {
 control "cis_kube_v120_v100_5_1_6" {
   title         = "5.1.6 Ensure that Service Account Tokens are only mounted where necessary"
   description   = "Mounting service account tokens inside pods can provide an avenue for privilege escalation attacks where an attacker is able to compromise a single pod in the cluster. Avoiding mounting these tokens removes this attack avenue."
-  sql           = query.pod_service_account_token_disabled.sql
+  query         = query.pod_service_account_token_disabled
   documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_1_6.md")
 
   tags = merge(local.cis_kube_v120_v100_5_common_tags, {
@@ -132,7 +132,7 @@ control "cis_kube_v120_v100_5_1_6" {
 control "cis_kube_v120_v100_5_2_1" {
   title         = "5.2.1 Minimize the admission of privileged containers"
   description   = "Privileged containers have access to all Linux Kernel capabilities and devices. A container running with full privileges can do almost everything that the host can do. This flag exists to allow special use-cases, like manipulating the network stack and accessing devices. There should be at least one PodSecurityPolicy (PSP) defined which does not permit privileged containers."
-  sql           = query.pod_security_policy_container_privilege_disabled.sql
+  query         = query.pod_security_policy_container_privilege_disabled
   documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_2_1.md")
 
   tags = merge(local.cis_kube_v120_v100_5_common_tags, {
@@ -146,7 +146,7 @@ control "cis_kube_v120_v100_5_2_1" {
 control "cis_kube_v120_v100_5_2_2" {
   title         = "5.2.2 Minimize the admission of containers wishing to share the host process ID namespace"
   description   = "A container running in the host's PID namespace can inspect processes running outside the container. If the container also has access to ptrace capabilities this can be used to escalate privileges outside of the container. There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host PID namespace."
-  sql           = query.pod_security_policy_hostpid_sharing_disabled.sql
+  query         = query.pod_security_policy_hostpid_sharing_disabled
   documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_2_2.md")
 
   tags = merge(local.cis_kube_v120_v100_5_common_tags, {
@@ -160,7 +160,7 @@ control "cis_kube_v120_v100_5_2_2" {
 control "cis_kube_v120_v100_5_2_3" {
   title         = "5.2.3 Minimize the admission of containers wishing to share the host IPC namespace"
   description   = "A container running in the host's IPC namespace can use IPC to interact with processes outside the container. There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host IPC namespace."
-  sql           = query.pod_security_policy_hostipc_sharing_disabled.sql
+  query         = query.pod_security_policy_hostipc_sharing_disabled
   documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_2_3.md")
 
   tags = merge(local.cis_kube_v120_v100_5_common_tags, {
@@ -174,7 +174,7 @@ control "cis_kube_v120_v100_5_2_3" {
 control "cis_kube_v120_v100_5_2_4" {
   title         = "5.2.4 Minimize the admission of containers wishing to share the host network namespace"
   description   = "A container running in the host's network namespace could access the local loopback device, and could access network traffic to and from other pods. There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to share the host network namespace."
-  sql           = query.pod_security_policy_host_network_access_disabled.sql
+  query         = query.pod_security_policy_host_network_access_disabled
   documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_2_4.md")
 
   tags = merge(local.cis_kube_v120_v100_5_common_tags, {
@@ -188,7 +188,7 @@ control "cis_kube_v120_v100_5_2_4" {
 control "cis_kube_v120_v100_5_2_5" {
   title         = "5.2.5 Minimize the admission of containers with allowPrivilegeEscalation"
   description   = "A container running with the `allowPrivilegeEscalation` flag set to true may have processes that can gain more privileges than their parent. There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to allow privilege escalation. The option exists (and is defaulted to true) to permit setuid binaries to run."
-  sql           = query.pod_security_policy_container_privilege_escalation_disabled.sql
+  query         = query.pod_security_policy_container_privilege_escalation_disabled
   documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_2_5.md")
 
   tags = merge(local.cis_kube_v120_v100_5_common_tags, {
@@ -202,7 +202,7 @@ control "cis_kube_v120_v100_5_2_5" {
 control "cis_kube_v120_v100_5_2_6" {
   title         = "5.2.6 Minimize the admission of root containers"
   description   = "Containers may run as any Linux user. Containers which run as the root user, whilst constrained by Container Runtime security features still have a escalated likelihood of container breakout. There should be at least one PodSecurityPolicy (PSP) defined which does not permit root users in a container."
-  sql           = query.pod_security_policy_non_root_container.sql
+  query         = query.pod_security_policy_non_root_container
   documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_2_6.md")
 
   tags = merge(local.cis_kube_v120_v100_5_common_tags, {

--- a/controls/config_map.sp
+++ b/controls/config_map.sp
@@ -7,7 +7,7 @@ locals {
 control "config_map_default_namespace_used" {
   title       = "ConfigMap definition should not use default namespace"
   description = "Default namespace should not be used by ConfigMap definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.config_map_default_namespace_used.sql
+  query       = query.config_map_default_namespace_used
 
   tags = merge(local.config_map_common_tags, {
     cis = "true"

--- a/controls/cronjob.sp
+++ b/controls/cronjob.sp
@@ -7,7 +7,7 @@ locals {
 control "cronjob_cpu_limit" {
   title       = replace(local.container_cpu_limit_title, "__KIND__", "CronJob")
   description = replace(local.container_cpu_limit_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_cpu_limit.sql
+  query       = query.cronjob_cpu_limit
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "cronjob_cpu_limit" {
 control "cronjob_cpu_request" {
   title       = replace(local.container_cpu_request_title, "__KIND__", "CronJob")
   description = replace(local.container_cpu_request_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_cpu_request.sql
+  query       = query.cronjob_cpu_request
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "cronjob_cpu_request" {
 control "cronjob_memory_limit" {
   title       = replace(local.container_memory_limit_title, "__KIND__", "CronJob")
   description = replace(local.container_memory_limit_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_memory_limit.sql
+  query       = query.cronjob_memory_limit
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "cronjob_memory_limit" {
 control "cronjob_memory_request" {
   title       = replace(local.container_memory_request_title, "__KIND__", "CronJob")
   description = replace(local.container_memory_request_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_memory_request.sql
+  query       = query.cronjob_memory_request
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "cronjob_memory_request" {
 control "cronjob_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "CronJob")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_container_privilege_disabled.sql
+  query       = query.cronjob_container_privilege_disabled
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "cronjob_container_privilege_disabled" {
 control "cronjob_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "CronJob")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_container_privilege_escalation_disabled.sql
+  query       = query.cronjob_container_privilege_escalation_disabled
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "cronjob_container_privilege_escalation_disabled" {
 control "cronjob_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "CronJob")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_host_network_access_disabled.sql
+  query       = query.cronjob_host_network_access_disabled
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "cronjob_host_network_access_disabled" {
 control "cronjob_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "CronJob")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_hostpid_hostipc_sharing_disabled.sql
+  query       = query.cronjob_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "cronjob_hostpid_hostipc_sharing_disabled" {
 control "cronjob_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "CronJob")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_immutable_container_filesystem.sql
+  query       = query.cronjob_immutable_container_filesystem
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -97,7 +97,7 @@ control "cronjob_immutable_container_filesystem" {
 control "cronjob_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "CronJob")
   description = replace(local.non_root_container_desc, "__KIND__", "CronJob")
-  sql         = query.cronjob_non_root_container.sql
+  query       = query.cronjob_non_root_container
 
   tags = merge(local.cronjob_common_tags, {
     nsa_cisa_v1 = "true"
@@ -107,7 +107,7 @@ control "cronjob_non_root_container" {
 control "cronjob_container_readiness_probe" {
   title       = "CronJob containers should have readiness probe"
   description = "Containers in CronJob definition should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill its work."
-  sql         = query.cronjob_container_readiness_probe.sql
+  query       = query.cronjob_container_readiness_probe
 
   tags = merge(local.cronjob_common_tags, {
     extra_checks = "true"
@@ -117,7 +117,7 @@ control "cronjob_container_readiness_probe" {
 control "cronjob_container_liveness_probe" {
   title       = "CronJob containers should have liveness probe"
   description = "Containers in CronJob definition should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.cronjob_container_liveness_probe.sql
+  query       = query.cronjob_container_liveness_probe
 
   tags = merge(local.cronjob_common_tags, {
     extra_checks = "true"
@@ -127,7 +127,7 @@ control "cronjob_container_liveness_probe" {
 control "cronjob_container_privilege_port_mapped" {
   title       = "CronJob containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with CronJob containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.cronjob_container_privilege_port_mapped.sql
+  query       = query.cronjob_container_privilege_port_mapped
 
   tags = merge(local.cronjob_common_tags, {
     extra_checks = "true"
@@ -137,7 +137,7 @@ control "cronjob_container_privilege_port_mapped" {
 control "cronjob_default_namespace_used" {
   title       = "CronJob definition should not use default namespace"
   description = "Default namespace should not be used by CronJob definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.cronjob_default_namespace_used.sql
+  query       = query.cronjob_default_namespace_used
 
   tags = merge(local.cronjob_common_tags, {
     cis = "true"
@@ -147,7 +147,7 @@ control "cronjob_default_namespace_used" {
 control "cronjob_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in CronJob definition"
   description = "In CronJob definition seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.cronjob_default_seccomp_profile_enabled.sql
+  query       = query.cronjob_default_seccomp_profile_enabled
 
   tags = merge(local.cronjob_common_tags, {
     cis = "true"

--- a/controls/daemonset.sp
+++ b/controls/daemonset.sp
@@ -7,7 +7,7 @@ locals {
 control "daemonset_cpu_limit" {
   title       = replace(local.container_cpu_limit_title, "__KIND__", "DaemonSet")
   description = replace(local.container_cpu_limit_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_cpu_limit.sql
+  query       = query.daemonset_cpu_limit
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "daemonset_cpu_limit" {
 control "daemonset_cpu_request" {
   title       = replace(local.container_cpu_request_title, "__KIND__", "DaemonSet")
   description = replace(local.container_cpu_request_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_cpu_request.sql
+  query       = query.daemonset_cpu_request
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "daemonset_cpu_request" {
 control "daemonset_memory_limit" {
   title       = replace(local.container_memory_limit_title, "__KIND__", "DaemonSet")
   description = replace(local.container_memory_limit_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_memory_limit.sql
+  query       = query.daemonset_memory_limit
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "daemonset_memory_limit" {
 control "daemonset_memory_request" {
   title       = replace(local.container_memory_request_title, "__KIND__", "DaemonSet")
   description = replace(local.container_memory_request_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_memory_request.sql
+  query       = query.daemonset_memory_request
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "daemonset_memory_request" {
 control "daemonset_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "DaemonSet")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_container_privilege_disabled.sql
+  query       = query.daemonset_container_privilege_disabled
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "daemonset_container_privilege_disabled" {
 control "daemonset_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "DaemonSet")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_container_privilege_escalation_disabled.sql
+  query       = query.daemonset_container_privilege_escalation_disabled
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "daemonset_container_privilege_escalation_disabled" {
 control "daemonset_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "DaemonSet")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_host_network_access_disabled.sql
+  query       = query.daemonset_host_network_access_disabled
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "daemonset_host_network_access_disabled" {
 control "daemonset_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "DaemonSet")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_hostpid_hostipc_sharing_disabled.sql
+  query       = query.daemonset_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "daemonset_hostpid_hostipc_sharing_disabled" {
 control "daemonset_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "DaemonSet")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_immutable_container_filesystem.sql
+  query       = query.daemonset_immutable_container_filesystem
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -97,7 +97,7 @@ control "daemonset_immutable_container_filesystem" {
 control "daemonset_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "DaemonSet")
   description = replace(local.non_root_container_desc, "__KIND__", "DaemonSet")
-  sql         = query.daemonset_non_root_container.sql
+  query       = query.daemonset_non_root_container
 
   tags = merge(local.daemonset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -107,7 +107,7 @@ control "daemonset_non_root_container" {
 control "daemonset_container_readiness_probe" {
   title       = "DaemonSet containers should have readiness probe"
   description = "Containers in DaemonSet definition should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill it’s work."
-  sql         = query.daemonset_container_readiness_probe.sql
+  query       = query.daemonset_container_readiness_probe
 
   tags = merge(local.daemonset_common_tags, {
     extra_checks = "true"
@@ -117,7 +117,7 @@ control "daemonset_container_readiness_probe" {
 control "daemonset_container_liveness_probe" {
   title       = "DaemonSet containers should have liveness probe"
   description = "Containers in DaemonSet definition should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.daemonset_container_liveness_probe.sql
+  query       = query.daemonset_container_liveness_probe
 
   tags = merge(local.daemonset_common_tags, {
     extra_checks = "true"
@@ -127,7 +127,7 @@ control "daemonset_container_liveness_probe" {
 control "daemonset_container_privilege_port_mapped" {
   title       = "DaemonSet containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with DaemonSet containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.daemonset_container_privilege_port_mapped.sql
+  query       = query.daemonset_container_privilege_port_mapped
 
   tags = merge(local.daemonset_common_tags, {
     extra_checks = "true"
@@ -137,7 +137,7 @@ control "daemonset_container_privilege_port_mapped" {
 control "daemonset_default_namespace_used" {
   title       = "DaemonSet definition should not use default namespace"
   description = "Default namespace should not be used by DaemonSet definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.daemonset_default_namespace_used.sql
+  query       = query.daemonset_default_namespace_used
 
   tags = merge(local.daemonset_common_tags, {
     cis = "true"
@@ -147,7 +147,7 @@ control "daemonset_default_namespace_used" {
 control "daemonset_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in DaemonSet definition"
   description = "In DaemonSet definition seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.daemonset_default_seccomp_profile_enabled.sql
+  query       = query.daemonset_default_seccomp_profile_enabled
 
   tags = merge(local.daemonset_common_tags, {
     cis = "true"

--- a/controls/deployment.sp
+++ b/controls/deployment.sp
@@ -7,7 +7,7 @@ locals {
 control "deployment_cpu_limit" {
   title       = replace(local.container_cpu_limit_title, "__KIND__", "Deployment")
   description = replace(local.container_cpu_limit_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_cpu_limit.sql
+  query       = query.deployment_cpu_limit
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "deployment_cpu_limit" {
 control "deployment_cpu_request" {
   title       = replace(local.container_cpu_request_title, "__KIND__", "Deployment")
   description = replace(local.container_cpu_request_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_cpu_request.sql
+  query       = query.deployment_cpu_request
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "deployment_cpu_request" {
 control "deployment_memory_limit" {
   title       = replace(local.container_memory_limit_title, "__KIND__", "Deployment")
   description = replace(local.container_memory_limit_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_memory_limit.sql
+  query       = query.deployment_memory_limit
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "deployment_memory_limit" {
 control "deployment_memory_request" {
   title       = replace(local.container_memory_request_title, "__KIND__", "Deployment")
   description = replace(local.container_memory_request_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_memory_request.sql
+  query       = query.deployment_memory_request
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "deployment_memory_request" {
 control "deployment_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "Deployment")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_container_privilege_disabled.sql
+  query       = query.deployment_container_privilege_disabled
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "deployment_container_privilege_disabled" {
 control "deployment_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "Deployment")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_container_privilege_escalation_disabled.sql
+  query       = query.deployment_container_privilege_escalation_disabled
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "deployment_container_privilege_escalation_disabled" {
 control "deployment_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "Deployment")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_host_network_access_disabled.sql
+  query       = query.deployment_host_network_access_disabled
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "deployment_host_network_access_disabled" {
 control "deployment_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "Deployment")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_hostpid_hostipc_sharing_disabled.sql
+  query       = query.deployment_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "deployment_hostpid_hostipc_sharing_disabled" {
 control "deployment_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "Deployment")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_immutable_container_filesystem.sql
+  query       = query.deployment_immutable_container_filesystem
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -97,7 +97,7 @@ control "deployment_immutable_container_filesystem" {
 control "deployment_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "Deployment")
   description = replace(local.non_root_container_desc, "__KIND__", "Deployment")
-  sql         = query.deployment_non_root_container.sql
+  query       = query.deployment_non_root_container
 
   tags = merge(local.deployment_common_tags, {
     nsa_cisa_v1 = "true"
@@ -107,7 +107,7 @@ control "deployment_non_root_container" {
 control "deployment_container_readiness_probe" {
   title       = "Deployment containers should have readiness probe"
   description = "Containers in Deployment definition should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill it’s work."
-  sql         = query.deployment_container_readiness_probe.sql
+  query       = query.deployment_container_readiness_probe
 
   tags = merge(local.deployment_common_tags, {
     extra_checks = "true"
@@ -117,7 +117,7 @@ control "deployment_container_readiness_probe" {
 control "deployment_container_liveness_probe" {
   title       = "Deployment containers should have liveness probe"
   description = "Containers in Deployment definition should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.deployment_container_liveness_probe.sql
+  query       = query.deployment_container_liveness_probe
 
   tags = merge(local.deployment_common_tags, {
     extra_checks = "true"
@@ -127,7 +127,7 @@ control "deployment_container_liveness_probe" {
 control "deployment_container_privilege_port_mapped" {
   title       = "Deployment containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with deployment containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.deployment_container_privilege_port_mapped.sql
+  query       = query.deployment_container_privilege_port_mapped
 
   tags = merge(local.deployment_common_tags, {
     extra_checks = "true"
@@ -137,7 +137,7 @@ control "deployment_container_privilege_port_mapped" {
 control "deployment_default_namespace_used" {
   title       = "Deployment definition should not use default namespace"
   description = "Default namespace should not be used by deployment definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.deployment_default_namespace_used.sql
+  query       = query.deployment_default_namespace_used
 
   tags = merge(local.deployment_common_tags, {
     cis = "true"
@@ -147,7 +147,7 @@ control "deployment_default_namespace_used" {
 control "deployment_replica_minimum_3" {
   title       = "Deployment should have a minimum of 3 replicas"
   description = "Replicas in the deployment should be at least 3 to increase the fault tolerance of the deployment."
-  sql         = query.deployment_replica_minimum_3.sql
+  query       = query.deployment_replica_minimum_3
 
   tags = merge(local.deployment_common_tags, {
     extra_checks = "true"
@@ -157,7 +157,7 @@ control "deployment_replica_minimum_3" {
 control "deployment_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in Deployment definition"
   description = "In Deployment definition seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.deployment_default_seccomp_profile_enabled.sql
+  query       = query.deployment_default_seccomp_profile_enabled
 
   tags = merge(local.deployment_common_tags, {
     cis = "true"

--- a/controls/endpoint.sp
+++ b/controls/endpoint.sp
@@ -7,7 +7,7 @@ locals {
 control "endpoint_api_serve_on_secure_port" {
   title       = "Kubernetes API should serve on secure port"
   description = "Kubernetes API should serve on port 443 or port 6443, protected by TLS. Once TLS is established, the HTTP request moves to the authentication step. If the request cannot be authenticated, it is rejected with HTTP status code 401."
-  sql         = query.endpoint_api_serve_on_secure_port.sql
+  query = query.endpoint_api_serve_on_secure_port
 
   tags = merge(local.endpoint_common_tags, {
     nsa_cisa_v1 = "true"

--- a/controls/ingress.sp
+++ b/controls/ingress.sp
@@ -7,7 +7,7 @@ locals {
 control "ingress_default_namespace_used" {
   title       = "Ingress definition should not use default namespace"
   description = "Default namespace should not be used by Ingress definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.ingress_default_namespace_used.sql
+  query       = query.ingress_default_namespace_used
 
   tags = merge(local.ingress_common_tags, {
     cis = "true"

--- a/controls/job.sp
+++ b/controls/job.sp
@@ -7,7 +7,7 @@ locals {
 control "job_cpu_limit" {
   title       = replace(local.container_cpu_limit_title, "__KIND__", "Job")
   description = replace(local.container_cpu_limit_desc, "__KIND__", "Job")
-  sql         = query.job_cpu_limit.sql
+  query       = query.job_cpu_limit
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "job_cpu_limit" {
 control "job_cpu_request" {
   title       = replace(local.container_cpu_request_title, "__KIND__", "Job")
   description = replace(local.container_cpu_request_desc, "__KIND__", "Job")
-  sql         = query.job_cpu_request.sql
+  query       = query.job_cpu_request
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "job_cpu_request" {
 control "job_memory_limit" {
   title       = replace(local.container_memory_limit_title, "__KIND__", "Job")
   description = replace(local.container_memory_limit_desc, "__KIND__", "Job")
-  sql         = query.job_memory_limit.sql
+  query       = query.job_memory_limit
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "job_memory_limit" {
 control "job_memory_request" {
   title       = replace(local.container_memory_request_title, "__KIND__", "Job")
   description = replace(local.container_memory_request_desc, "__KIND__", "Job")
-  sql         = query.job_memory_request.sql
+  query       = query.job_memory_request
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "job_memory_request" {
 control "job_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "Job")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "Job")
-  sql         = query.job_container_privilege_disabled.sql
+  query       = query.job_container_privilege_disabled
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "job_container_privilege_disabled" {
 control "job_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "Job")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "Job")
-  sql         = query.job_container_privilege_escalation_disabled.sql
+  query       = query.job_container_privilege_escalation_disabled
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "job_container_privilege_escalation_disabled" {
 control "job_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "Job")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "Job")
-  sql         = query.job_host_network_access_disabled.sql
+  query       = query.job_host_network_access_disabled
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "job_host_network_access_disabled" {
 control "job_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "Job")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "Job")
-  sql         = query.job_hostpid_hostipc_sharing_disabled.sql
+  query       = query.job_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "job_hostpid_hostipc_sharing_disabled" {
 control "job_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "Job")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "Job")
-  sql         = query.job_immutable_container_filesystem.sql
+  query       = query.job_immutable_container_filesystem
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -97,7 +97,7 @@ control "job_immutable_container_filesystem" {
 control "job_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "Job")
   description = replace(local.non_root_container_desc, "__KIND__", "Job")
-  sql         = query.job_non_root_container.sql
+  query       = query.job_non_root_container
 
   tags = merge(local.job_common_tags, {
     nsa_cisa_v1 = "true"
@@ -107,7 +107,7 @@ control "job_non_root_container" {
 control "job_container_readiness_probe" {
   title       = "Job containers should have readiness probe"
   description = "Containers in Job definition should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill it’s work."
-  sql         = query.job_container_readiness_probe.sql
+  query       = query.job_container_readiness_probe
 
   tags = merge(local.job_common_tags, {
     extra_checks = "true"
@@ -117,7 +117,7 @@ control "job_container_readiness_probe" {
 control "job_container_liveness_probe" {
   title       = "Job containers should have liveness probe"
   description = "Containers in Job definition should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.job_container_liveness_probe.sql
+  query       = query.job_container_liveness_probe
 
   tags = merge(local.job_common_tags, {
     extra_checks = "true"
@@ -127,14 +127,14 @@ control "job_container_liveness_probe" {
 control "job_container_privilege_port_mapped" {
   title       = "Job containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with Job containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.job_container_privilege_port_mapped.sql
+  query       = query.job_container_privilege_port_mapped
   tags        = local.extra_checks_tags
 }
 
 control "job_default_namespace_used" {
   title       = "Job definition should not use default namespace"
   description = "Default namespace should not be used by Job definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.job_default_namespace_used.sql
+  query       = query.job_default_namespace_used
 
   tags = merge(local.job_common_tags, {
     cis = "true"
@@ -144,7 +144,7 @@ control "job_default_namespace_used" {
 control "job_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in Job definition"
   description = "In Job definition seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.job_default_seccomp_profile_enabled.sql
+  query       = query.job_default_seccomp_profile_enabled
 
   tags = merge(local.job_common_tags, {
     cis = "true"

--- a/controls/namespace.sp
+++ b/controls/namespace.sp
@@ -7,7 +7,7 @@ locals {
 control "namespace_limit_range_default_cpu_limit" {
   title       = "Namespaces should have default CPU limit in limitRange policy"
   description = "Administrators should use default limitRange policy for CPU limit for each namespace."
-  sql         = query.namespace_limit_range_default_cpu_limit.sql
+  query       = query.namespace_limit_range_default_cpu_limit
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "namespace_limit_range_default_cpu_limit" {
 control "namespace_resource_quota_cpu_limit" {
   title       = "Namespaces should be restricted on CPU usage with resourceQuota CPU limit"
   description = "Administrators should use resourceQuota CPU limit to restrict namespaces CPU usage."
-  sql         = query.namespace_resource_quota_cpu_limit.sql
+  query       = query.namespace_resource_quota_cpu_limit
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "namespace_resource_quota_cpu_limit" {
 control "namespace_limit_range_default_cpu_request" {
   title       = "Namespaces should have default CPU request in limitRange policy"
   description = "Administrators should use default limitRange policy for CPU request for each namespace."
-  sql         = query.namespace_limit_range_default_cpu_request.sql
+  query       = query.namespace_limit_range_default_cpu_request
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "namespace_limit_range_default_cpu_request" {
 control "namespace_resource_quota_cpu_request" {
   title       = "Namespaces should have resourceQuota CPU request"
   description = "Administrators should use resourceQuota CPU request for each namespace."
-  sql         = query.namespace_resource_quota_cpu_request.sql
+  query       = query.namespace_resource_quota_cpu_request
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "namespace_resource_quota_cpu_request" {
 control "namespace_limit_range_default_memory_limit" {
   title       = "Namespaces should have default memory limit in limitRange policy"
   description = "Administrators should use default limitRange policy for memory limit for each namespace."
-  sql         = query.namespace_limit_range_default_memory_limit.sql
+  query       = query.namespace_limit_range_default_memory_limit
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "namespace_limit_range_default_memory_limit" {
 control "namespace_resource_quota_memory_limit" {
   title       = "Namespaces should be restricted on memory usage with resourceQuota memory limit"
   description = "Administrators should use resourceQuota memory limit to restrict namespaces memory usage."
-  sql         = query.namespace_resource_quota_memory_limit.sql
+  query       = query.namespace_resource_quota_memory_limit
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "namespace_resource_quota_memory_limit" {
 control "namespace_limit_range_default_memory_request" {
   title       = "Namespaces should have default memory request in limitRange policy"
   description = "Administrators should use default limitRange policy for memory request for each namespace."
-  sql         = query.namespace_limit_range_default_memory_request.sql
+  query       = query.namespace_limit_range_default_memory_request
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "namespace_limit_range_default_memory_request" {
 control "namespace_resource_quota_memory_request" {
   title       = "Namespaces should have resourceQuota memory request"
   description = "Administrators should use resourceQuota memory request for each namespace."
-  sql         = query.namespace_resource_quota_memory_request.sql
+  query       = query.namespace_resource_quota_memory_request
 
   tags = merge(local.namespace_common_tags, {
     nsa_cisa_v1 = "true"

--- a/controls/network_policy.sp
+++ b/controls/network_policy.sp
@@ -7,7 +7,7 @@ locals {
 control "network_policy_default_deny_egress" {
   title       = "Namespaces should have a default network policy to deny all egress traffic"
   description = "Administrators should use a default policy selecting all Pods to deny all egress traffic and ensure any unselected Pods are isolated. Additional policies could then relax these restrictions for permissible connections."
-  sql         = query.network_policy_default_deny_egress.sql
+  query       = query.network_policy_default_deny_egress
 
   tags = merge(local.network_policy_common_tags, {
     cis         = "true"
@@ -18,7 +18,7 @@ control "network_policy_default_deny_egress" {
 control "network_policy_default_deny_ingress" {
   title       = "Namespaces should have a default network policy to deny all ingress traffic"
   description = "Administrators should use a default policy selecting all Pods to deny all ingress traffic and ensure any unselected Pods are isolated. Additional policies could then relax these restrictions for permissible connections."
-  sql         = query.network_policy_default_deny_ingress.sql
+  query       = query.network_policy_default_deny_ingress
 
   tags = merge(local.network_policy_common_tags, {
     cis         = "true"
@@ -29,7 +29,7 @@ control "network_policy_default_deny_ingress" {
 control "network_policy_default_dont_allow_egress" {
   title       = "Network policies should not have a default policy to allow all egress traffic"
   description = "Administrators should use a default policy selecting all Pods to deny all ingress and egress traffic and ensure any unselected Pods are isolated. An 'allow all' policy would override this default and should not be used.  Instead, use specific  policies to relax these restrictions only for permissible connections. "
-  sql         = query.network_policy_default_dont_allow_egress.sql
+  query       = query.network_policy_default_dont_allow_egress
 
   tags = merge(local.network_policy_common_tags, {
     cis         = "true"
@@ -40,7 +40,7 @@ control "network_policy_default_dont_allow_egress" {
 control "network_policy_default_dont_allow_ingress" {
   title       = "Network policies should not have a default policy to allow all ingress traffic"
   description = "Administrators should use a default policy selecting all Pods to deny all ingress and egress traffic and ensure any unselected Pods are isolated. An 'allow all' policy would override this default and should not be used.  Instead, use specific  policies to relax these restrictions only for permissible connections. "
-  sql         = query.network_policy_default_dont_allow_ingress.sql
+  query       = query.network_policy_default_dont_allow_ingress
 
   tags = merge(local.network_policy_common_tags, {
     cis         = "true"

--- a/controls/pod.sp
+++ b/controls/pod.sp
@@ -7,7 +7,7 @@ locals {
 control "pod_volume_host_path" {
   title       = replace(local.container_disallow_host_path_title, "__KIND__", "Pod")
   description = replace(local.container_disallow_host_path_desc, "__KIND__", "Pod")
-  sql         = query.pod_volume_host_path.sql
+  query       = query.pod_volume_host_path
 
   tags = merge(local.pod_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "pod_volume_host_path" {
 control "pod_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "Pod")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "Pod")
-  sql         = query.pod_container_privilege_disabled.sql
+  query       = query.pod_container_privilege_disabled
 
   tags = merge(local.pod_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "pod_container_privilege_disabled" {
 control "pod_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "Pod")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "Pod")
-  sql         = query.pod_container_privilege_escalation_disabled.sql
+  query       = query.pod_container_privilege_escalation_disabled
 
   tags = merge(local.pod_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,14 +37,14 @@ control "pod_container_privilege_escalation_disabled" {
 control "pod_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "Pod")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "Pod")
-  sql         = query.pod_host_network_access_disabled.sql
+  query       = query.pod_host_network_access_disabled
   tags        = local.nsa_cisa_v1_common_tags
 }
 
 control "pod_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "Pod")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "Pod")
-  sql         = query.pod_hostpid_hostipc_sharing_disabled.sql
+  query       = query.pod_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.pod_common_tags, {
     nsa_cisa_v1 = "true"
@@ -54,7 +54,7 @@ control "pod_hostpid_hostipc_sharing_disabled" {
 control "pod_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "Pod")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "Pod")
-  sql         = query.pod_immutable_container_filesystem.sql
+  query       = query.pod_immutable_container_filesystem
 
   tags = merge(local.pod_common_tags, {
     nsa_cisa_v1 = "true"
@@ -64,7 +64,7 @@ control "pod_immutable_container_filesystem" {
 control "pod_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "Pod")
   description = replace(local.non_root_container_desc, "__KIND__", "Pod")
-  sql         = query.pod_non_root_container.sql
+  query       = query.pod_non_root_container
 
   tags = merge(local.pod_common_tags, {
     nsa_cisa_v1 = "true"
@@ -74,7 +74,7 @@ control "pod_non_root_container" {
 control "pod_service_account_not_exist" {
   title       = "Pods should not refer to a non existing service account"
   description = local.pod_service_account_not_exist_desc
-  sql         = query.pod_service_account_not_exist.sql
+  query       = query.pod_service_account_not_exist
 
   tags = merge(local.pod_common_tags, {
     extra_checks = "true"
@@ -84,7 +84,7 @@ control "pod_service_account_not_exist" {
 control "pod_service_account_token_disabled" {
   title       = "Automatic mapping of the service account tokens should be disabled in Pod"
   description = local.service_account_token_disabled_desc
-  sql         = query.pod_service_account_token_disabled.sql
+  query       = query.pod_service_account_token_disabled
 
   tags = merge(local.pod_common_tags, {
     nsa_cisa_v1 = "true"
@@ -94,7 +94,7 @@ control "pod_service_account_token_disabled" {
 control "pod_container_readiness_probe" {
   title       = "Pod containers should have readiness probe"
   description = "Containers in Pods should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill it’s work."
-  sql         = query.pod_container_readiness_probe.sql
+  query       = query.pod_container_readiness_probe
 
   tags = merge(local.pod_common_tags, {
     extra_checks = "true"
@@ -104,7 +104,7 @@ control "pod_container_readiness_probe" {
 control "pod_container_liveness_probe" {
   title       = "Pod containers should have liveness probe"
   description = "Containers in Pods should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.pod_container_liveness_probe.sql
+  query       = query.pod_container_liveness_probe
 
   tags = merge(local.pod_common_tags, {
     extra_checks = "true"
@@ -114,7 +114,7 @@ control "pod_container_liveness_probe" {
 control "pod_container_privilege_port_mapped" {
   title       = "Pod containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with Pod containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.pod_container_privilege_port_mapped.sql
+  query       = query.pod_container_privilege_port_mapped
 
   tags = merge(local.pod_common_tags, {
     extra_checks = "true"
@@ -124,7 +124,7 @@ control "pod_container_privilege_port_mapped" {
 control "pod_default_namespace_used" {
   title       = "Pods should not use default namespace"
   description = "Default namespace should not be used by Pods. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.pod_default_namespace_used.sql
+  query       = query.pod_default_namespace_used
 
   tags = merge(local.pod_common_tags, {
     cis = "true"
@@ -134,7 +134,7 @@ control "pod_default_namespace_used" {
 control "pod_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in your Pods"
   description = "In Pods seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.pod_default_seccomp_profile_enabled.sql
+  query       = query.pod_default_seccomp_profile_enabled
 
   tags = merge(local.pod_common_tags, {
     cis = "true"

--- a/controls/pod_security_policy.sp
+++ b/controls/pod_security_policy.sp
@@ -7,7 +7,7 @@ locals {
 control "pod_security_policy_allowed_host_path" {
   title       = "Pod Security Policy should prohibit hostPaths volumes"
   description = "The Pod Security Policy `allowedHostPaths` specifies a list of host paths that are allowed to be used by hostPath volumes. An empty list means there is no restriction on host paths used. This is defined as a list of objects with a single pathPrefix field, which allows hostPath volumes to mount a path that begins with an allowed prefix, and a readOnly field indicating it must be mounted read-only."
-  sql         = query.pod_security_policy_allowed_host_path.sql
+  query       = query.pod_security_policy_allowed_host_path
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "pod_security_policy_allowed_host_path" {
 control "pod_security_policy_container_privilege_disabled" {
   title       = "Pod Security Policy should prohibit containers to run with privilege access"
   description = "Pod Security Policy `privileged` controls whether the Pod containers may run with `privileged` access. ${replace(local.container_privilege_disabled_desc, "__KIND__", "Pod")}"
-  sql         = query.pod_security_policy_container_privilege_disabled.sql
+  query       = query.pod_security_policy_container_privilege_disabled
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "pod_security_policy_container_privilege_disabled" {
 control "pod_security_policy_container_privilege_escalation_disabled" {
   title       = "Pod Security Policy should prohibit privilege escalation"
   description = "Pod Security Policy `allowPrivilegeEscalation` controls whether the Pod containers may request for privilege escalation. ${replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "Pod")}"
-  sql         = query.pod_security_policy_container_privilege_escalation_disabled.sql
+  query       = query.pod_security_policy_container_privilege_escalation_disabled
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "pod_security_policy_container_privilege_escalation_disabled" {
 control "pod_security_policy_security_services_hardening" {
   title       = "Containerized applications should use security services such as SELinux or AppArmor or Seccomp"
   description = "The underlying host OS needs to be secured in order to prevent container breaches from affecting the host. For this, Linux provides several out-of-the-box security modules. Some of the popular ones are SELinux, AppArmor and Seccomp."
-  sql         = query.pod_security_policy_security_services_hardening.sql
+  query       = query.pod_security_policy_security_services_hardening
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "pod_security_policy_security_services_hardening" {
 control "pod_security_policy_host_network_access_disabled" {
   title       = "Pod Security Policy should prohibit host network access "
   description = "Pod Security Policy host network controls whether the Pod may use the node network namespace. Doing so gives the Pod access to the loopback device, services listening on localhost, and could be used to snoop on network activity of other Pods on the same node."
-  sql         = query.pod_security_policy_host_network_access_disabled.sql
+  query       = query.pod_security_policy_host_network_access_disabled
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "pod_security_policy_host_network_access_disabled" {
 control "pod_security_policy_hostpid_hostipc_sharing_disabled" {
   title       = "Pod Security Policy should prohibit containers from sharing the host process namespaces"
   description = "Pod Security Policy `hostPID` and `hostIPC` controls whether the Pod may share the host process namespaces. ${replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "Pod")}"
-  sql         = query.pod_security_policy_hostpid_hostipc_sharing_disabled.sql
+  query       = query.pod_security_policy_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "pod_security_policy_hostpid_hostipc_sharing_disabled" {
 control "pod_security_policy_immutable_container_filesystem" {
   title       = "Pod Security Policy should force containers to run with read only root file system"
   description = "Pod Security Policy `readOnlyRootFilesystem` controls whether the Pod containers run with read only root file system. ${replace(local.immutable_container_filesystem_desc, "__KIND__", "Pod")}"
-  sql         = query.pod_security_policy_immutable_container_filesystem.sql
+  query       = query.pod_security_policy_immutable_container_filesystem
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "pod_security_policy_immutable_container_filesystem" {
 control "pod_security_policy_non_root_container" {
   title       = "Pod Security Policy should prohibit containers from running as root"
   description = "Pod Security Policy should prohibit containers from running as root. ${replace(local.non_root_container_desc, "__KIND__", "Pod")}"
-  sql         = query.pod_security_policy_non_root_container.sql
+  query       = query.pod_security_policy_non_root_container
 
   tags = merge(local.pod_security_policy_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "pod_security_policy_non_root_container" {
 control "pod_security_policy_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in Pod security policy"
   description = "In Pod security policy seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.pod_security_policy_default_seccomp_profile_enabled.sql
+  query       = query.pod_security_policy_default_seccomp_profile_enabled
 
   tags = merge(local.pod_security_policy_common_tags, {
     cis = "true"

--- a/controls/replicaset.sp
+++ b/controls/replicaset.sp
@@ -7,7 +7,7 @@ locals {
 control "replicaset_cpu_limit" {
   title       = replace(local.container_cpu_limit_title, "__KIND__", "ReplicaSet")
   description = replace(local.container_cpu_limit_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_cpu_limit.sql
+  query       = query.replicaset_cpu_limit
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "replicaset_cpu_limit" {
 control "replicaset_cpu_request" {
   title       = replace(local.container_cpu_request_title, "__KIND__", "ReplicaSet")
   description = replace(local.container_cpu_request_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_cpu_request.sql
+  query       = query.replicaset_cpu_request
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "replicaset_cpu_request" {
 control "replicaset_memory_limit" {
   title       = replace(local.container_memory_limit_title, "__KIND__", "ReplicaSet")
   description = replace(local.container_memory_limit_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_memory_limit.sql
+  query       = query.replicaset_memory_limit
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "replicaset_memory_limit" {
 control "replicaset_memory_request" {
   title       = replace(local.container_memory_request_title, "__KIND__", "ReplicaSet")
   description = replace(local.container_memory_request_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_memory_request.sql
+  query       = query.replicaset_memory_request
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "replicaset_memory_request" {
 control "replicaset_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "ReplicaSet")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_container_privilege_disabled.sql
+  query       = query.replicaset_container_privilege_disabled
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "replicaset_container_privilege_disabled" {
 control "replicaset_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "ReplicaSet")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_container_privilege_escalation_disabled.sql
+  query       = query.replicaset_container_privilege_escalation_disabled
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "replicaset_container_privilege_escalation_disabled" {
 control "replicaset_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "ReplicaSet")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_host_network_access_disabled.sql
+  query       = query.replicaset_host_network_access_disabled
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "replicaset_host_network_access_disabled" {
 control "replicaset_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "ReplicaSet")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_hostpid_hostipc_sharing_disabled.sql
+  query       = query.replicaset_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "replicaset_hostpid_hostipc_sharing_disabled" {
 control "replicaset_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "ReplicaSet")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_immutable_container_filesystem.sql
+  query       = query.replicaset_immutable_container_filesystem
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -97,7 +97,7 @@ control "replicaset_immutable_container_filesystem" {
 control "replicaset_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "ReplicaSet")
   description = replace(local.non_root_container_desc, "__KIND__", "ReplicaSet")
-  sql         = query.replicaset_non_root_container.sql
+  query       = query.replicaset_non_root_container
 
   tags = merge(local.replicaset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -107,7 +107,7 @@ control "replicaset_non_root_container" {
 control "replicaset_container_readiness_probe" {
   title       = "ReplicaSet containers should have readiness probe"
   description = "Containers in ReplicaSet definition should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill it’s work."
-  sql         = query.replicaset_container_readiness_probe.sql
+  query       = query.replicaset_container_readiness_probe
 
   tags = merge(local.replicaset_common_tags, {
     extra_checks = "true"
@@ -117,7 +117,7 @@ control "replicaset_container_readiness_probe" {
 control "replicaset_container_liveness_probe" {
   title       = "ReplicaSet containers should have liveness probe"
   description = "Containers in ReplicaSet definition should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.replicaset_container_liveness_probe.sql
+  query       = query.replicaset_container_liveness_probe
 
   tags = merge(local.replicaset_common_tags, {
     extra_checks = "true"
@@ -127,7 +127,7 @@ control "replicaset_container_liveness_probe" {
 control "replicaset_container_privilege_port_mapped" {
   title       = "ReplicaSet containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with ReplicaSet containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.replicaset_container_privilege_port_mapped.sql
+  query       = query.replicaset_container_privilege_port_mapped
 
   tags = merge(local.replicaset_common_tags, {
     extra_checks = "true"
@@ -137,7 +137,7 @@ control "replicaset_container_privilege_port_mapped" {
 control "replicaset_default_namespace_used" {
   title       = "ReplicaSet definition should not use default namespace"
   description = "Default namespace should not be used by ReplicaSet definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.replicaset_default_namespace_used.sql
+  query       = query.replicaset_default_namespace_used
 
   tags = merge(local.replicaset_common_tags, {
     cis = "true"
@@ -147,7 +147,7 @@ control "replicaset_default_namespace_used" {
 control "replicaset_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in your ReplicaSet definition"
   description = "In ReplicaSet definition seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.replicaset_default_seccomp_profile_enabled.sql
+  query       = query.replicaset_default_seccomp_profile_enabled
 
   tags = merge(local.replicaset_common_tags, {
     cis = "true"

--- a/controls/replication_controller.sp
+++ b/controls/replication_controller.sp
@@ -7,7 +7,7 @@ locals {
 control "replication_controller_cpu_limit" {
   title       = replace(local.container_cpu_limit_title, "__KIND__", "ReplicationController")
   description = replace(local.container_cpu_limit_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_cpu_limit.sql
+  query       = query.replication_controller_cpu_limit
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "replication_controller_cpu_limit" {
 control "replication_controller_cpu_request" {
   title       = replace(local.container_cpu_request_title, "__KIND__", "ReplicationController")
   description = replace(local.container_cpu_request_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_cpu_request.sql
+  query       = query.replication_controller_cpu_request
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "replication_controller_cpu_request" {
 control "replication_controller_memory_limit" {
   title       = replace(local.container_memory_limit_title, "__KIND__", "ReplicationController")
   description = replace(local.container_memory_limit_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_memory_limit.sql
+  query       = query.replication_controller_memory_limit
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "replication_controller_memory_limit" {
 control "replication_controller_memory_request" {
   title       = replace(local.container_memory_request_title, "__KIND__", "ReplicationController")
   description = replace(local.container_memory_request_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_memory_request.sql
+  query       = query.replication_controller_memory_request
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "replication_controller_memory_request" {
 control "replication_controller_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "ReplicationController")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_container_privilege_disabled.sql
+  query       = query.replication_controller_container_privilege_disabled
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "replication_controller_container_privilege_disabled" {
 control "replication_controller_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "ReplicationController")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_container_privilege_escalation_disabled.sql
+  query       = query.replication_controller_container_privilege_escalation_disabled
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "replication_controller_container_privilege_escalation_disabled" {
 control "replication_controller_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "ReplicationController")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_host_network_access_disabled.sql
+  query       = query.replication_controller_host_network_access_disabled
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "replication_controller_host_network_access_disabled" {
 control "replication_controller_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "ReplicationController")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_hostpid_hostipc_sharing_disabled.sql
+  query       = query.replication_controller_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "replication_controller_hostpid_hostipc_sharing_disabled" {
 control "replication_controller_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "ReplicationController")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_immutable_container_filesystem.sql
+  query       = query.replication_controller_immutable_container_filesystem
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -97,7 +97,7 @@ control "replication_controller_immutable_container_filesystem" {
 control "replication_controller_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "ReplicationController")
   description = replace(local.non_root_container_desc, "__KIND__", "ReplicationController")
-  sql         = query.replication_controller_non_root_container.sql
+  query       = query.replication_controller_non_root_container
 
   tags = merge(local.replication_controller_common_tags, {
     nsa_cisa_v1 = "true"
@@ -107,7 +107,7 @@ control "replication_controller_non_root_container" {
 control "replication_controller_container_readiness_probe" {
   title       = "ReplicationController containers should have readiness probe"
   description = "Containers in ReplicationController definition should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill it’s work."
-  sql         = query.replication_controller_container_readiness_probe.sql
+  query       = query.replication_controller_container_readiness_probe
 
   tags = merge(local.replication_controller_common_tags, {
     extra_checks = "true"
@@ -117,7 +117,7 @@ control "replication_controller_container_readiness_probe" {
 control "replication_controller_container_liveness_probe" {
   title       = "ReplicationController containers should have liveness probe"
   description = "Containers in ReplicationController definition should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.replication_controller_container_liveness_probe.sql
+  query       = query.replication_controller_container_liveness_probe
 
   tags = merge(local.replication_controller_common_tags, {
     extra_checks = "true"
@@ -127,7 +127,7 @@ control "replication_controller_container_liveness_probe" {
 control "replication_controller_container_privilege_port_mapped" {
   title       = "ReplicationController containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with ReplicationController containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.replication_controller_container_privilege_port_mapped.sql
+  query       = query.replication_controller_container_privilege_port_mapped
 
   tags = merge(local.replication_controller_common_tags, {
     extra_checks = "true"
@@ -137,7 +137,7 @@ control "replication_controller_container_privilege_port_mapped" {
 control "replication_controller_default_namespace_used" {
   title       = "ReplicationController definition should not use default namespace"
   description = "Default namespace should not be used by ReplicationController definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.replication_controller_default_namespace_used.sql
+  query       = query.replication_controller_default_namespace_used
 
   tags = merge(local.replication_controller_common_tags, {
     cis = "true"
@@ -147,7 +147,7 @@ control "replication_controller_default_namespace_used" {
 control "replication_controller_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in your Replication Controller definition"
   description = "In Replication Controller definition seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.replication_controller_default_seccomp_profile_enabled.sql
+  query       = query.replication_controller_default_seccomp_profile_enabled
 
   tags = merge(local.replication_controller_common_tags, {
     cis = "true"

--- a/controls/role.sp
+++ b/controls/role.sp
@@ -7,7 +7,7 @@ locals {
 control "role_default_namespace_used" {
   title       = "Role definition should not use default namespace"
   description = "Default namespace should not be used by Role definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.role_default_namespace_used.sql
+  query       = query.role_default_namespace_used
 
   tags = merge(local.role_common_tags, {
     cis = "true"

--- a/controls/role_binding.sp
+++ b/controls/role_binding.sp
@@ -7,7 +7,7 @@ locals {
 control "role_binding_default_namespace_used" {
   title       = "RoleBinding definition should not use default namespace"
   description = "Default namespace should not be used by RoleBinding definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.role_binding_default_namespace_used.sql
+  query       = query.role_binding_default_namespace_used
 
   tags = merge(local.role_binding_common_tags, {
     cis = "true"

--- a/controls/secret.sp
+++ b/controls/secret.sp
@@ -7,7 +7,7 @@ locals {
 control "secret_default_namespace_used" {
   title       = "Secret definition should not use default namespace"
   description = "Default namespace should not be used by Secret definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.secret_default_namespace_used.sql
+  query       = query.secret_default_namespace_used
 
   tags = merge(local.secret_common_tags, {
     cis = "true"

--- a/controls/service.sp
+++ b/controls/service.sp
@@ -7,7 +7,7 @@ locals {
 control "service_type_forbidden" {
   title       = "Containers should not be exposed through a forbidden service type"
   description = local.service_type_forbidden_desc
-  sql         = query.service_type_forbidden.sql
+  query       = query.service_type_forbidden
 
   tags = merge(local.service_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "service_type_forbidden" {
 control "service_default_namespace_used" {
   title       = "Services should not use default namespace"
   description = "Default namespace should not be used by services. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.service_default_namespace_used.sql
+  query       = query.service_default_namespace_used
 
   tags = merge(local.service_common_tags, {
     cis = "true"

--- a/controls/service_account.sp
+++ b/controls/service_account.sp
@@ -7,7 +7,7 @@ locals {
 control "service_account_token_disabled" {
   title       = "Automatic mapping of the service account tokens should be disabled in service account"
   description = local.service_account_token_disabled_desc
-  sql         = query.service_account_token_disabled.sql
+  query       = query.service_account_token_disabled
 
   tags = merge(local.service_account_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "service_account_token_disabled" {
 control "service_account_default_namespace_used" {
   title       = "ServiceAccount definition should not use default namespace"
   description = "Default namespace should not be used by ServiceAccount definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.service_account_default_namespace_used.sql
+  query       = query.service_account_default_namespace_used
 
   tags = merge(local.service_account_common_tags, {
     cis = "true"

--- a/controls/statefulset.sp
+++ b/controls/statefulset.sp
@@ -7,7 +7,7 @@ locals {
 control "statefulset_cpu_limit" {
   title       = replace(local.container_cpu_limit_title, "__KIND__", "StatefulSet")
   description = replace(local.container_cpu_limit_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_cpu_limit.sql
+  query       = query.statefulset_cpu_limit
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -17,7 +17,7 @@ control "statefulset_cpu_limit" {
 control "statefulset_cpu_request" {
   title       = replace(local.container_cpu_request_title, "__KIND__", "StatefulSet")
   description = replace(local.container_cpu_request_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_cpu_request.sql
+  query       = query.statefulset_cpu_request
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -27,7 +27,7 @@ control "statefulset_cpu_request" {
 control "statefulset_memory_limit" {
   title       = replace(local.container_memory_limit_title, "__KIND__", "StatefulSet")
   description = replace(local.container_memory_limit_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_memory_limit.sql
+  query       = query.statefulset_memory_limit
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -37,7 +37,7 @@ control "statefulset_memory_limit" {
 control "statefulset_memory_request" {
   title       = replace(local.container_memory_request_title, "__KIND__", "StatefulSet")
   description = replace(local.container_memory_request_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_memory_request.sql
+  query       = query.statefulset_memory_request
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -47,7 +47,7 @@ control "statefulset_memory_request" {
 control "statefulset_container_privilege_disabled" {
   title       = replace(local.container_privilege_disabled_title, "__KIND__", "StatefulSet")
   description = replace(local.container_privilege_disabled_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_container_privilege_disabled.sql
+  query       = query.statefulset_container_privilege_disabled
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -57,7 +57,7 @@ control "statefulset_container_privilege_disabled" {
 control "statefulset_container_privilege_escalation_disabled" {
   title       = replace(local.container_privilege_escalation_disabled_title, "__KIND__", "StatefulSet")
   description = replace(local.container_privilege_escalation_disabled_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_container_privilege_escalation_disabled.sql
+  query       = query.statefulset_container_privilege_escalation_disabled
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -67,7 +67,7 @@ control "statefulset_container_privilege_escalation_disabled" {
 control "statefulset_host_network_access_disabled" {
   title       = replace(local.host_network_access_disabled_title, "__KIND__", "StatefulSet")
   description = replace(local.host_network_access_disabled_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_host_network_access_disabled.sql
+  query       = query.statefulset_host_network_access_disabled
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -77,7 +77,7 @@ control "statefulset_host_network_access_disabled" {
 control "statefulset_hostpid_hostipc_sharing_disabled" {
   title       = replace(local.hostpid_hostipc_sharing_disabled_title, "__KIND__", "StatefulSet")
   description = replace(local.hostpid_hostipc_sharing_disabled_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_hostpid_hostipc_sharing_disabled.sql
+  query       = query.statefulset_hostpid_hostipc_sharing_disabled
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -87,7 +87,7 @@ control "statefulset_hostpid_hostipc_sharing_disabled" {
 control "statefulset_immutable_container_filesystem" {
   title       = replace(local.immutable_container_filesystem_title, "__KIND__", "StatefulSet")
   description = replace(local.immutable_container_filesystem_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_immutable_container_filesystem.sql
+  query       = query.statefulset_immutable_container_filesystem
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -97,7 +97,7 @@ control "statefulset_immutable_container_filesystem" {
 control "statefulset_non_root_container" {
   title       = replace(local.non_root_container_title, "__KIND__", "StatefulSet")
   description = replace(local.non_root_container_desc, "__KIND__", "StatefulSet")
-  sql         = query.statefulset_non_root_container.sql
+  query       = query.statefulset_non_root_container
 
   tags = merge(local.statefulset_common_tags, {
     nsa_cisa_v1 = "true"
@@ -107,7 +107,7 @@ control "statefulset_non_root_container" {
 control "statefulset_container_readiness_probe" {
   title       = "StatefulSet containers should have readiness probe"
   description = "Containers in StatefulSet definition should have readiness probe. The readiness probes in turn also check dependencies like database connections or other services your container is depending on to fulfill it’s work."
-  sql         = query.statefulset_container_readiness_probe.sql
+  query       = query.statefulset_container_readiness_probe
 
   tags = merge(local.statefulset_common_tags, {
     extra_checks = "true"
@@ -117,7 +117,7 @@ control "statefulset_container_readiness_probe" {
 control "statefulset_container_liveness_probe" {
   title       = "StatefulSet containers should have liveness probe"
   description = "Containers in StatefulSet definition should have liveness probe. The liveness probes are to check if the container is started and alive. If this isn’t the case, kubernetes will eventually restart the container."
-  sql         = query.statefulset_container_liveness_probe.sql
+  query       = query.statefulset_container_liveness_probe
 
   tags = merge(local.statefulset_common_tags, {
     extra_checks = "true"
@@ -127,7 +127,7 @@ control "statefulset_container_liveness_probe" {
 control "statefulset_container_privilege_port_mapped" {
   title       = "StatefulSet containers should not be mapped with privilege ports"
   description = "Privileged ports `0 to 1024` should not be mapped with StatefulSet containers. Normal users and processes are not allowed to use them for various security reasons."
-  sql         = query.statefulset_container_privilege_port_mapped.sql
+  query       = query.statefulset_container_privilege_port_mapped
 
   tags = merge(local.statefulset_common_tags, {
     extra_checks = "true"
@@ -137,7 +137,7 @@ control "statefulset_container_privilege_port_mapped" {
 control "statefulset_default_namespace_used" {
   title       = "StatefulSet definition should not use default namespace"
   description = "Default namespace should not be used by StatefulSet definition. Placing objects in this namespace makes application of RBAC and other controls more difficult."
-  sql         = query.statefulset_default_namespace_used.sql
+  query       = query.statefulset_default_namespace_used
 
   tags = merge(local.statefulset_common_tags, {
     cis = "true"
@@ -147,7 +147,7 @@ control "statefulset_default_namespace_used" {
 control "statefulset_default_seccomp_profile_enabled" {
   title       = "Seccomp profile is set to docker/default in your StatefulSet definition"
   description = "In StatefulSet definition seccomp profile should be set to docker/default. Seccomp (secure computing mode) is used to restrict the set of system calls applications can make, allowing cluster administrators greater control over the security of workloads running in the cluster. Kubernetes disables seccomp profiles by default for historical reasons. It should be enabled to ensure that the workloads have restricted actions available within the container."
-  sql         = query.statefulset_default_seccomp_profile_enabled.sql
+  query       = query.statefulset_default_seccomp_profile_enabled
 
   tags = merge(local.statefulset_common_tags, {
     cis = "true"


### PR DESCRIPTION
This occurs throughout the mod, but as a specific example:
```sql
control "cis_kube_v120_v100_5_2_5" { 
title         = "5.2.5 Minimize the admission of containers with allowPrivilegeEscalation" 
description   = "A container running with the `allowPrivilegeEscalation` flag set to true may have processes that can gain more privileges than their parent. There should be at least one PodSecurityPolicy (PSP) defined which does not permit containers to allow privilege escalation. The option exists (and is defaulted to true) to permit setuid binaries to run." 
sql           = query.pod_security_policy_container_privilege_escalation_disabled.sql 
documentation = file("./cis_kube_v120/docs/cis_kube_v120_v100_5_2_5.md") 
  
tags = merge(local.cis_kube_v120_v100_5_common_tags, { 
 cis_level   = "1" 
 cis_item_id = "5.2.5" 
 cis_type    = "automated" 
 service     = "Kubernetes/PodSecurityPolicy" 
   }) 
 } 
```
This is changed from:
```
  sql           = query.pod_security_policy_container_privilege_escalation_disabled.sql
```

to:
```
  query         = query.pod_security_policy_container_privilege_escalation_disabled
```
